### PR TITLE
chore: Correct command in README to verify forge zksync installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ forge script script/DeploySimpleStorage.s.sol --private-key <PRIVATE_KEY> --rpc-
 
 ### Prerequisites
 - [foundry-zksync](https://github.com/matter-labs/foundry-zksync)
-  - You'll know you've done it right if you can run `forge-zksync --version` and you see a response like `forge-zksync 0.0.2 (816e00b 2023-03-16T00:05:26.396218Z)`
+  - You'll know you've done it right if you can run `forge --version` and you see a response like `forge 0.0.2 (816e00b 2023-03-16T00:05:26.396218Z)`
+  - If you're unsure whether you're using vanilla or zkSync, note that for zkSync it is `0.0.2`, and for vanilla it is `0.2.0` (these are versions which may change over time).
+
 - [docker](https://docs.docker.com/engine/install/)
   - You'll know you've done it right if you can run `docker --version` and you see a response like `Docker version 20.10.7, build f0df350`
 - [nodejs & npm](https://nodejs.org/en/download/package-manager)


### PR DESCRIPTION
This PR corrects a command in the README file from `forge-zksync --version` to `forge --version`. This change ensures users are verifying the correct installation version of `forge`. Additionally, a note has been added to clarify the version numbers for vanilla and zkSync, mentioning that these versions may change over time.

### Changes

- Updated command to `forge --version`.
- Added a note explaining the version differences for vanilla and zkSync, with a mention that versions may change over time.

### Verification

- Run `forge --version` to see the response `forge 0.0.2` for verification.
- Clarified that for zkSync it is `0.0.2`, and for vanilla it is `0.2.0` (noting that these versions may change over time).

### Checklist

- [x] Updated the README file.
- [x] Verified the correct command and version numbers.

Please review the changes and merge if everything looks good.
